### PR TITLE
Fixes #147 Build nightly: don't skip the build step if workflow was started manually.

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -38,7 +38,7 @@ jobs:
 
   build-nightly:
     needs: get-latest-commit-timespan
-    if: needs.get-latest-commit-timespan.outputs.LATEST_COMMIT_TIMESPAN < 86400
+    if: needs.get-latest-commit-timespan.outputs.LATEST_COMMIT_TIMESPAN < 86400 || github.event_name == 'workflow_dispatch'
     runs-on: windows-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Some background: the build nightly workflow was automatically deactivated by GitHub some time ago due to 60 days of inactivity in the repository. After that, there were commits to the repository (e.g. update of the OSPSuite.Core version), but no new nigthly builds (because the workflow remained inactivated).

I reactivated the workflow and triggered nightly build locally, but the build was skipped because the latest commit was older than 1 day.