### PR TITLE
Fixes #152 When starting a MoBi Qualification, pass the PK-Sim path on the command line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -330,3 +330,4 @@ ASALocalRun/
 .mfractor/
 
 setup/
+*.ncrunchsolution

--- a/src/QualificationRunner.Core/Constants.cs
+++ b/src/QualificationRunner.Core/Constants.cs
@@ -23,6 +23,7 @@ namespace QualificationRunner.Core
 
       public static class Tools
       {
+         public static readonly string PKSIM = "PKSim.exe";
          public static readonly string PKSIM_CLI = "PKSim.CLI.exe";
          public static readonly string BATCH_LOG = "batch.log";
          public static readonly string MOBI_CLI = "MoBi.CLI.exe";

--- a/src/QualificationRunner.Core/QualificationRunner.Core.csproj
+++ b/src/QualificationRunner.Core/QualificationRunner.Core.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <Version>12.0.0</Version>
     <PackageVersion>12.0.0</PackageVersion>
     <AssemblyVersion>12.0.0</AssemblyVersion>
@@ -16,32 +15,27 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="..\..\SolutionInfo.cs" Link="Properties\SolutionInfo.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="..\..\LICENSE">
       <Pack>True</Pack>
-      <PackagePath></PackagePath>
+      <PackagePath>
+      </PackagePath>
     </None>
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.32" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.32" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.32" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.51" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.7" />
   </ItemGroup>
-
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 </Project>

--- a/src/QualificationRunner.Core/Services/QualificationEngine.cs
+++ b/src/QualificationRunner.Core/Services/QualificationEngine.cs
@@ -66,22 +66,34 @@ namespace QualificationRunner.Core.Services
 
          _logger.AddDebug(Logs.QualificationConfigurationForProjectExportedTo(project, configFile));
 
-         var cliPath = qualificationConfiguration.Application == ApplicationType.PKSim
-            ? _applicationConfiguration.PKSimCLIPathFor(runOptions.PKSimInstallationFolder)
-            : _applicationConfiguration.MoBiCLIPathFor(runOptions.MoBiInstallationFolder);
+         string cliPath, moBiPKSimStarterPath = string.Empty;
+         if (qualificationConfiguration.Application == ApplicationType.PKSim)
+            cliPath = _applicationConfiguration.PKSimCLIPathFor(runOptions.PKSimInstallationFolder);
+         else
+         {
+
+            cliPath = _applicationConfiguration.MoBiCLIPathFor(runOptions.MoBiInstallationFolder);
+            
+            // If the PK-Sim folder was specified by command line argument the intent is to inform MoBi which PK-Sim instance
+            // should be used for PK-Sim services.
+            if (!string.IsNullOrEmpty(runOptions.PKSimInstallationFolder))
+               moBiPKSimStarterPath = Path.Combine(runOptions.PKSimInstallationFolder, Constants.Tools.PKSIM);
+         }
 
          if (!FileHelper.FileExists(cliPath))
             throw new QualificationRunException(Errors.CliFileNotFound(cliPath));
 
          return await Task.Run(() =>
          {
-            var code = startBatchProcess(configFile, logFilePaths.ToList(), runOptions.LogLevel, validate, cliPath, runOptions.Run, runOptions.ExportProjectFiles, cancellationToken);
+            var args = createArgs(configFile, logFilePaths.ToList(), runOptions.LogLevel, validate, runOptions.Run, runOptions.ExportProjectFiles, moBiPKSimStarterPath);
+            
+            var code = startBatchProcess(args, cliPath, cancellationToken);
             qualificationRunResult.Success = (code == ExitCodes.Success);
             return qualificationRunResult;
          }, cancellationToken);
       }
 
-      private ExitCodes startBatchProcess(string configFile, List<string> logFilePaths, LogLevel logLevel, bool validate, string cliPath, bool run, bool exportProjectFiles, CancellationToken cancellationToken)
+      private static List<string> createArgs(string configFile, List<string> logFilePaths, LogLevel logLevel, bool validate, bool run, bool exportProjectFiles, string pkSimPath)
       {
          var quotedPaths = logFilePaths.Select(element => element.InQuotes());
 
@@ -105,6 +117,14 @@ namespace QualificationRunner.Core.Services
          if (validate)
             args.Add("-v");
 
+         if (!string.IsNullOrEmpty(pkSimPath))
+            args.AddRange(new[] { "-p", pkSimPath });
+
+         return args;
+      }
+
+      private ExitCodes startBatchProcess(List<string> args, string cliPath, CancellationToken cancellationToken)
+      {
          using (var process = _startableProcessFactory.CreateStartableProcess(cliPath, args.ToArray()))
          {
             process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;

--- a/src/QualificationRunner/QualificationRunner.csproj
+++ b/src/QualificationRunner/QualificationRunner.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <Version>12.0.0</Version>
     <OutputType>Exe</OutputType>
     <Version>12.0.0</Version>
@@ -20,25 +19,21 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>1591, 3246</NoWarn>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="..\..\SolutionInfo.cs" Link="Properties\SolutionInfo.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="..\..\LICENSE" Link="LICENSE">
-      <PackagePath></PackagePath>
+      <PackagePath>
+      </PackagePath>
       <Pack>True</Pack>
     </None>
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.7" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\QualificationRunner.Core\QualificationRunner.Core.csproj" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Fixes #152
Optionally tell MoBi where to find the PK-Sim installation that should be used to recreate modules from snapshot.

I also updated to .NET 8 and specified Windows because we are reading from the registry in some spots.