### PR TITLE
Fixes #108 Too many PKSim.CLI processes

### DIFF
--- a/src/QualificationRunner.Core/Extensions/HttpClientExtensions.cs
+++ b/src/QualificationRunner.Core/Extensions/HttpClientExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace QualificationRunner.Core.Extensions;
+
+public static class HttpClientExtensions
+{
+   public static async Task DownloadFileTaskAsync(this HttpClient client, Uri uri, string fileName)
+   {
+      await using var s = await client.GetStreamAsync(uri);
+      await using var fs = new FileStream(fileName, FileMode.CreateNew);
+      await s.CopyToAsync(fs);
+   }
+}

--- a/src/QualificationRunner.Core/Extensions/HttpClientExtensions.cs
+++ b/src/QualificationRunner.Core/Extensions/HttpClientExtensions.cs
@@ -9,8 +9,8 @@ public static class HttpClientExtensions
 {
    public static async Task DownloadFileTaskAsync(this HttpClient client, Uri uri, string fileName)
    {
-      await using var s = await client.GetStreamAsync(uri);
-      await using var fs = new FileStream(fileName, FileMode.CreateNew);
-      await s.CopyToAsync(fs);
+      await using var stream = await client.GetStreamAsync(uri);
+      await using var fileStream = new FileStream(fileName, FileMode.CreateNew);
+      await stream.CopyToAsync(fileStream);
    }
 }

--- a/src/QualificationRunner.Core/QualificationRunner.Core.csproj
+++ b/src/QualificationRunner.Core/QualificationRunner.Core.csproj
@@ -19,6 +19,7 @@
     <Compile Include="..\..\SolutionInfo.cs" Link="Properties\SolutionInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Folder Include="Extensions\" />
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
@@ -30,9 +31,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.51" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.51" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.52" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.52" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.52" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.7" />
   </ItemGroup>
   <ItemGroup>

--- a/src/QualificationRunner.Core/QualificationRunnerRegister.cs
+++ b/src/QualificationRunner.Core/QualificationRunnerRegister.cs
@@ -1,5 +1,4 @@
 ﻿using Castle.Facilities.TypedFactory;
-using Microsoft.Extensions.Logging;
 using OSPSuite.Core;
 using OSPSuite.Core.Services;
 using OSPSuite.Infrastructure;

--- a/src/QualificationRunner.Core/Services/QualificationEngine.cs
+++ b/src/QualificationRunner.Core/Services/QualificationEngine.cs
@@ -71,9 +71,8 @@ namespace QualificationRunner.Core.Services
             cliPath = _applicationConfiguration.PKSimCLIPathFor(runOptions.PKSimInstallationFolder);
          else
          {
-
             cliPath = _applicationConfiguration.MoBiCLIPathFor(runOptions.MoBiInstallationFolder);
-            
+
             // If the PK-Sim folder was specified by command line argument the intent is to inform MoBi which PK-Sim instance
             // should be used for PK-Sim services.
             if (!string.IsNullOrEmpty(runOptions.PKSimInstallationFolder))
@@ -86,7 +85,7 @@ namespace QualificationRunner.Core.Services
          return await Task.Run(() =>
          {
             var args = createArgs(configFile, logFilePaths.ToList(), runOptions.LogLevel, validate, runOptions.Run, runOptions.ExportProjectFiles, moBiPKSimStarterPath);
-            
+
             var code = startBatchProcess(args, cliPath, cancellationToken);
             qualificationRunResult.Success = (code == ExitCodes.Success);
             return qualificationRunResult;
@@ -128,7 +127,7 @@ namespace QualificationRunner.Core.Services
          using (var process = _startableProcessFactory.CreateStartableProcess(cliPath, args.ToArray()))
          {
             process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
-            process.Start();
+            process.Start(ProcessPriorityClass.Idle);
             process.Wait(cancellationToken);
             return (ExitCodes)process.ReturnCode;
          }

--- a/src/QualificationRunner.Core/Services/QualificationRunner.cs
+++ b/src/QualificationRunner.Core/Services/QualificationRunner.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
@@ -13,6 +13,7 @@ using OSPSuite.Core.Services;
 using OSPSuite.Utility;
 using OSPSuite.Utility.Extensions;
 using QualificationRunner.Core.Domain;
+using QualificationRunner.Core.Extensions;
 using QualificationRunner.Core.RunOptions;
 using static QualificationRunner.Core.Assets.Errors;
 using static QualificationRunner.Core.Constants;
@@ -93,14 +94,15 @@ namespace QualificationRunner.Core.Services
          var downloadFolder = Path.Combine(_runOptions.TempFolder, locationInTempFolder);
          DirectoryHelper.CreateDirectory(downloadFolder);
 
-         using (var wc = new WebClient())
+         using (var wc = new HttpClient())
          {
             try
             {
-               var fileName = new Uri(url).Segments.Last();
+               var uri = new Uri(url);
+               var fileName = uri.Segments.Last();
                var fileFullPath = Path.Combine(downloadFolder, fileName);
 
-               await wc.DownloadFileTaskAsync(url, fileFullPath);
+               await wc.DownloadFileTaskAsync(uri, fileFullPath);
                _logger.AddDebug($"{type} file downloaded from {url} to {fileFullPath}");
                return fileFullPath;
             }


### PR DESCRIPTION
Adjusting the process priority level when starting a qualification.

`WebClient` is obsolete, so I replaced it with `HttpClient`

<img width="1427" height="900" alt="image" src="https://github.com/user-attachments/assets/494dd92d-6949-4099-a7a0-bb2851f6a3a7" />
