### PR TITLE
Fixes #159 Sign executables with code signing certificate

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -1,5 +1,6 @@
 # Changing the workflow name will reset the run number
-name: Build Nightly 12.1
+name: Build Nightly 12.2
+run-name: Version 12.2.${{ github.run_number }}
 
 on:
   workflow_dispatch:
@@ -8,9 +9,13 @@ on:
 
 env:
   MAJOR: 12
-  MINOR: 1
+  MINOR: 2
   RUN: ${{ github.run_number }}
   TARGET_FRAMEWORK: net8
+
+permissions:
+  contents: read
+  packages: read
 
 jobs:
   get-latest-commit-timespan:
@@ -70,7 +75,17 @@ jobs:
       - name: Build
         run: |
           msbuild QualificationRunner.sln /p:Version=${{env.APP_VERSION}}
-      
+
+      - name: Sign QualificationRunner.exe with CodeSignTool
+        uses: Open-Systems-Pharmacology/Workflows/.github/actions/codesigner-SSL@main
+        env:
+          ES_USERNAME: ${{ secrets.ES_USERNAME }}
+          ES_PASSWORD: ${{ secrets.ES_PASSWORD }}
+          ES_CREDENTIAL_ID: ${{ secrets.ES_CREDENTIAL_ID }}
+          ES_TOTP_SECRET: ${{ secrets.ES_TOTP_SECRET }}
+        with:
+          file_path: ./src/QualificationRunner/bin/Debug/net472/QualificationRunner.exe
+
       - name: Create Portable Setup
         run: |
           rake "create_portable_setup[${{env.APP_VERSION}}, Debug, qualificationrunner-portable-setup.zip]"


### PR DESCRIPTION
Fixes #159 Sign executables with code signing certificate
Fixes #158 build-nightly: add version to the run number
Fixes #161 Add explicit GHA permissions to avoid code scanning warnings
Also incremented the version 12.1=>12.2