### PR TITLE
Nightly badge

### DIFF
--- a/.github/workflows/nightly-badge.yml
+++ b/.github/workflows/nightly-badge.yml
@@ -1,0 +1,29 @@
+name: Badge for Nightly Build
+# This workflow acts as a proxy for the nightly build workflow. 
+# Upon completion of a nightly build, it is invoked to update a repository badge 
+# according to the latest run's result.
+#
+# Behavior summary:
+#   1. If the triggering workflow_run's conclusion is 'success' -> this workflow succeeds (badge passing).
+#   2. If the triggering workflow_run concluded with a non-cancelled failure (e.g. failure, timed_out)
+#      -> this workflow exits with a non-zero status (badge failing).
+#   3. If the triggering workflow_run concluded with 'cancelled' -> this workflow will query the
+#      GitHub Actions API for the latest non-cancelled run of the specified nightly workflow:
+#        - If the latest non-cancelled run's conclusion is 'success', treat the badge as passing.
+#        - Otherwise, exit non-zero (badge failing).
+
+on:
+  workflow_run:
+    workflows:
+      - "Build Nightly 12.2"
+    types:
+      - completed
+
+permissions:
+  actions: read
+
+jobs:
+  badge:
+    uses: Open-Systems-Pharmacology/Workflows/.github/workflows/nightly-badge.yml@main
+    with:
+      nightly-build-workflow: "build-nightly.yml"

--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
-# QualificationRunner
-Qualification runner in charge of managing a qualification workflow
+# Qualification Runner
+Qualification runner in charge of managing a qualification workflow.
 
 ## Code Status
-[![Build status](https://img.shields.io/github/actions/workflow/status/Open-Systems-Pharmacology/QualificationRunner/build-nightly.yml?logo=nuget&label=Build%20status)](https://github.com/Open-Systems-Pharmacology/QualificationRunner/actions/workflows/build-nightly.yml)
-
+[![Build status](https://img.shields.io/github/actions/workflow/status/Open-Systems-Pharmacology/QualificationRunner/nightly-badge.yml?logo=GitHub&label=Build%20status)](https://github.com/Open-Systems-Pharmacology/QualificationRunner/actions/workflows/build-nightly.yml)
 
 ## Code of conduct
 Everyone interacting in the Open Systems Pharmacology community (codebases, issue trackers, chat rooms, mailing lists etc...) is expected to follow the Open Systems Pharmacology [code of conduct](https://github.com/Open-Systems-Pharmacology/Suite/blob/master/CODE_OF_CONDUCT.md).
 
 ## Contribution
-We encourage contribution to the Open Systems Pharmacology community. Before getting started please read the [contribution guidelines](https://github.com/Open-Systems-Pharmacology/Suite/blob/master/CONTRIBUTING.md). If you are contributing code, please be familiar with the [coding standards](https://github.com/Open-Systems-Pharmacology/Suite/blob/master/CODING_STANDARDS.md).
+We encourage contribution to the Open Systems Pharmacology community. Before getting started please read the [contribution guidelines](https://github.com/Open-Systems-Pharmacology/Suite/blob/master/CONTRIBUTING.md). If you are contributing code, please be familiar with the [coding standards](https://dev.open-systems-pharmacology.org/setup/coding_standards).
 
 ## License
-QualificationRunnerx`x` is released under the [GPLv2 License](https://github.com/Open-Systems-Pharmacology/Suite/blob/master/LICENSE).
+Qualification Runner is released under the [GPLv2 License](https://github.com/Open-Systems-Pharmacology/Suite/blob/master/LICENSE).
 
 All trademarks within this document belong to their legitimate owners.

--- a/src/QualificationRunner.Core/QualificationRunner.Core.csproj
+++ b/src/QualificationRunner.Core/QualificationRunner.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <TargetFramework>net472</TargetFramework>
-    <Version Condition="'$(Version)' == ''">12.1.0</Version>
+    <Version Condition="'$(Version)' == ''">12.2.0</Version>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <Authors>Open-Systems-Pharmacology</Authors>
@@ -11,6 +11,7 @@
     <OutputPath>bin\$(Configuration)</OutputPath>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -30,9 +31,9 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.128" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.1.128" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.1.128" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.20" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.2.20" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.2.20" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.0" />
   </ItemGroup>
 

--- a/src/QualificationRunner/QualificationRunner.csproj
+++ b/src/QualificationRunner/QualificationRunner.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <TargetFramework>net472</TargetFramework>
-    <Version Condition="'$(Version)' == ''">12.1.0</Version>
+    <Version Condition="'$(Version)' == ''">12.2.0</Version>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
@@ -14,6 +14,7 @@
     <OutputPath>bin\$(Configuration)</OutputPath>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <NoWarn>1591, 3246</NoWarn>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #163 Use the Proxy-Workflow for the nightly build status badge
Fixes #164 Increment version 12.1=>12.2

Also updated OSPSuite.Core to the latest 12.2