### PR TITLE
Fixes #174 

### DIFF
--- a/src/QualificationRunner.Core/Services/QualificationRunner.cs
+++ b/src/QualificationRunner.Core/Services/QualificationRunner.cs
@@ -65,7 +65,8 @@ namespace QualificationRunner.Core.Services
          StaticFiles staticFiles = await copyStaticFiles(qualificationPlan);
 
          _logger.AddInfo("Starting validation runs...");
-         var validations = await Task.WhenAll(projectConfigurations.Select(validateProject));
+         var numberOfCores = Environment.ProcessorCount;
+         var validations = await runThrottled(projectConfigurations, validateProject, numberOfCores);
 
          var invalidConfigurations = validations.Where(x => !x.Success).ToList();
          if (invalidConfigurations.Any())
@@ -73,7 +74,7 @@ namespace QualificationRunner.Core.Services
 
          //Run all qualification projects
          _logger.AddInfo("Starting qualification runs...");
-         var runResults = await Task.WhenAll(projectConfigurations.Select(runQualification));
+         var runResults = await runThrottled(projectConfigurations, runQualification, numberOfCores);
          var invalidRunResults = runResults.Where(x => !x.Success).ToList();
          if (invalidRunResults.Any())
             throw new QualificationRunException(errorMessageFrom(invalidRunResults));
@@ -86,6 +87,30 @@ namespace QualificationRunner.Core.Services
       }
 
       private Task updateProjectsFullPath(IReadOnlyList<Project> projects) => Task.WhenAll(projects.Select(updateProjectFullPath));
+
+      private async Task<QualificationRunResult[]> runThrottled(
+         QualifcationConfiguration[] configurations,
+         Func<QualifcationConfiguration, Task<QualificationRunResult>> action,
+         int maxDegreeOfParallelism)
+      {
+         using (var semaphore = new SemaphoreSlim(maxDegreeOfParallelism))
+         {
+            var tasks = configurations.Select(async config =>
+            {
+               await semaphore.WaitAsync();
+               try
+               {
+                  return await action(config);
+               }
+               finally
+               {
+                  semaphore.Release();
+               }
+            }).ToArray();
+
+            return await Task.WhenAll(tasks);
+         }
+      }
 
       private async Task<string> downloadRemoteFile(string url, string locationInTempFolder, string type)
       {


### PR DESCRIPTION
Fixes #174

Finally, PKSim.CLI.exe created in parallel are <= NumberOfCores

Running the DDI-CYP3A4 qualification plan locally was about 15% faster and consumed max. 60-70% RAM instead of 100% before.

<img width="245" height="240" alt="grafik" src="https://github.com/user-attachments/assets/cd5a7be6-06ea-4b9d-b681-b31784d2f4d3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced parallel processing efficiency with adaptive concurrency management that optimizes resource utilization based on available system resources while maintaining existing error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->