### PR TITLE
Fixes #173 Unnecessary starts of PKSim.CLI.exe

### DIFF
--- a/src/QualificationRunner.Core/Extensions.cs
+++ b/src/QualificationRunner.Core/Extensions.cs
@@ -1,4 +1,8 @@
-﻿namespace QualificationRunner.Core
+﻿using OSPSuite.Core.Qualification;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QualificationRunner.Core
 {
    public static class StringExtensions
    {
@@ -10,6 +14,34 @@
       public static string InQuotes(this string stringToSurround)
       {
          return stringToSurround.SurroundWith("\"");
+      }
+   }
+
+   public static class QualificationConfigurationExtensions
+   {
+      /// <summary>
+      /// Evaluates whether the specified qualification configuration contains elements 
+      /// (such as simulations, inputs, or simulation plots) that require further processing.
+      /// </summary>
+      /// <param name="config">The qualification configuration to evaluate.</param>
+      /// <returns>
+      /// <c>true</c> if the configuration contains any simulations, inputs, or simulation plots; 
+      /// otherwise, <c>false</c>.
+      /// </returns>
+      /// <remarks>
+      /// This method is critical for determining which configurations should be included in 
+      /// subsequent processing steps. For more details, refer to the GitHub issue: 
+      /// <see href="https://github.com/Open-Systems-Pharmacology/QualificationRunner/issues/173" />.
+      /// </remarks>
+      public static bool MustBeExportedForFurtherProcessing(this QualifcationConfiguration config)
+      {
+         return config != null && 
+            (hasAnyElements(config.Simulations) || hasAnyElements(config.Inputs) || hasAnyElements(config.SimulationPlots));
+      }
+
+      private static bool hasAnyElements<T>(IEnumerable<T> collection)
+      {
+         return collection != null && collection.Any();
       }
    }
 }

--- a/src/QualificationRunner.Core/Services/QualificationRunner.cs
+++ b/src/QualificationRunner.Core/Services/QualificationRunner.cs
@@ -95,7 +95,8 @@ namespace QualificationRunner.Core.Services
       {
          using (var semaphore = new SemaphoreSlim(maxDegreeOfParallelism))
          {
-            var tasks = configurations.Where(mustBeExportedForFurtherProcessing).Select(async config =>
+            var tasks = configurations.Where(config => config.MustBeExportedForFurtherProcessing())
+               .Select(async config =>
             {
                await semaphore.WaitAsync();
                try
@@ -110,26 +111,6 @@ namespace QualificationRunner.Core.Services
 
             return await Task.WhenAll(tasks);
          }
-      }
-
-      /// <summary>
-      /// Evaluates whether the specified qualification configuration contains elements 
-      /// (such as simulations, inputs, or simulation plots) that require further processing.
-      /// </summary>
-      /// <param name="config">The qualification configuration to evaluate.</param>
-      /// <returns>
-      /// <c>true</c> if the configuration contains any simulations, inputs, or simulation plots; 
-      /// otherwise, <c>false</c>.
-      /// </returns>
-      /// <remarks>
-      /// This method is critical for determining which configurations should be included in 
-      /// subsequent processing steps. For more details, refer to the GitHub issue: 
-      /// <see href="https://github.com/Open-Systems-Pharmacology/QualificationRunner/issues/173" />.
-      /// </remarks>
-      private bool mustBeExportedForFurtherProcessing(QualifcationConfiguration config)
-      {
-         return (config.Simulations != null && config.Simulations.Any()) || (config.Inputs != null && config.Inputs.Any()) ||
-                (config.SimulationPlots != null && config.SimulationPlots.Any());
       }
 
       private async Task<string> downloadRemoteFile(string url, string locationInTempFolder, string type)

--- a/src/QualificationRunner.Core/Services/QualificationRunner.cs
+++ b/src/QualificationRunner.Core/Services/QualificationRunner.cs
@@ -95,7 +95,7 @@ namespace QualificationRunner.Core.Services
       {
          using (var semaphore = new SemaphoreSlim(maxDegreeOfParallelism))
          {
-            var tasks = configurations.Select(async config =>
+            var tasks = configurations.Where(mustBeExportedForFurtherProcessing).Select(async config =>
             {
                await semaphore.WaitAsync();
                try
@@ -110,6 +110,26 @@ namespace QualificationRunner.Core.Services
 
             return await Task.WhenAll(tasks);
          }
+      }
+
+      /// <summary>
+      /// Evaluates whether the specified qualification configuration contains elements 
+      /// (such as simulations, inputs, or simulation plots) that require further processing.
+      /// </summary>
+      /// <param name="config">The qualification configuration to evaluate.</param>
+      /// <returns>
+      /// <c>true</c> if the configuration contains any simulations, inputs, or simulation plots; 
+      /// otherwise, <c>false</c>.
+      /// </returns>
+      /// <remarks>
+      /// This method is critical for determining which configurations should be included in 
+      /// subsequent processing steps. For more details, refer to the GitHub issue: 
+      /// <see href="https://github.com/Open-Systems-Pharmacology/QualificationRunner/issues/173" />.
+      /// </remarks>
+      private bool mustBeExportedForFurtherProcessing(QualifcationConfiguration config)
+      {
+         return (config.Simulations != null && config.Simulations.Any()) || (config.Inputs != null && config.Inputs.Any()) ||
+                (config.SimulationPlots != null && config.SimulationPlots.Any());
       }
 
       private async Task<string> downloadRemoteFile(string url, string locationInTempFolder, string type)

--- a/tests/QualificationRunner.Tests/QualificationConfigurationExtensionsSpecs.cs
+++ b/tests/QualificationRunner.Tests/QualificationConfigurationExtensionsSpecs.cs
@@ -1,0 +1,86 @@
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Qualification;
+using QualificationRunner.Core;
+
+namespace QualificationRunner.Tests
+{
+   public abstract class concern_for_QualificationConfigurationExtensions : ContextSpecification<QualifcationConfiguration>
+   {
+      protected override void Context()
+      {
+         sut = new QualifcationConfiguration();
+      }
+
+   }
+
+   public class When_checking_if_a_configuration_must_be_exported_for_further_processing_and_no_references_exist : concern_for_QualificationConfigurationExtensions
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut = new QualifcationConfiguration();
+      }
+
+      [Observation]
+      public void should_not_be_exported()
+      {
+         sut.MustBeExportedForFurtherProcessing().ShouldBeFalse();
+      }
+   }
+
+   public class When_checking_if_a_configuration_must_be_exported_for_further_processing_and_simulations_exist : concern_for_QualificationConfigurationExtensions
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut = new QualifcationConfiguration
+         {
+            Simulations = new[] { "Simulation1" }
+         };
+      }
+
+      [Observation]
+      public void should_be_exported()
+      {
+         sut.MustBeExportedForFurtherProcessing().ShouldBeTrue();
+      }
+   }
+
+   public class When_checking_if_a_configuration_must_be_exported_for_further_processing_and_inputs_exist : concern_for_QualificationConfigurationExtensions
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut = new QualifcationConfiguration
+         {
+            Inputs = new[] { new Input() }
+         };
+      }
+
+      [Observation]
+      public void should_be_exported()
+      {
+         sut.MustBeExportedForFurtherProcessing().ShouldBeTrue();
+      }
+   }
+
+   public class When_checking_if_a_configuration_must_be_exported_for_further_processing_and_simulation_plots_exist : concern_for_QualificationConfigurationExtensions
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut = new QualifcationConfiguration
+         {
+            SimulationPlots = new[] { new SimulationPlot() }
+         };
+      }
+
+      [Observation]
+      public void should_be_exported()
+      {
+         sut.MustBeExportedForFurtherProcessing().ShouldBeTrue();
+      }
+   }
+
+}

--- a/tests/QualificationRunner.Tests/Services/QualificationRunnerSpecs.cs
+++ b/tests/QualificationRunner.Tests/Services/QualificationRunnerSpecs.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using FakeItEasy;
 using Newtonsoft.Json.Linq;
 using OSPSuite.BDDHelper;
@@ -25,6 +26,14 @@ namespace QualificationRunner.Tests.Services
 
          sut = new QualificationRunner.Core.Services.QualificationRunner(_jsonSerializer, _logger, _qualificationEngineFactory);
       }
+
+      protected bool MustBeExportedForFurtherProcessing(QualifcationConfiguration configuration)
+      {
+         var method = typeof(QualificationRunner.Core.Services.QualificationRunner)
+            .GetMethod("mustBeExportedForFurtherProcessing", BindingFlags.Instance | BindingFlags.NonPublic);
+
+         return (bool)method.Invoke(sut, new object[] { configuration });
+      }
    }
 
    public class When_running_a_batch_and_the_configuration_file_does_not_exist : concern_for_QualificationRunner
@@ -46,6 +55,59 @@ namespace QualificationRunner.Tests.Services
       {
          The.Action(async () => await sut.RunBatchAsync(_runOptions))
             .ShouldThrowAn<QualificationRunException>();
+      }
+   }
+
+   public class When_checking_if_a_configuration_must_be_exported_for_further_processing_and_no_references_exist : concern_for_QualificationRunner
+   {
+      [Observation]
+      public void should_not_be_exported()
+      {
+         var configuration = new QualifcationConfiguration();
+
+         MustBeExportedForFurtherProcessing(configuration).ShouldBeFalse();
+      }
+   }
+
+   public class When_checking_if_a_configuration_must_be_exported_for_further_processing_and_simulations_exist : concern_for_QualificationRunner
+   {
+      [Observation]
+      public void should_be_exported()
+      {
+         var configuration = new QualifcationConfiguration
+         {
+            Simulations = new[] { "Simulation1" }
+         };
+
+         MustBeExportedForFurtherProcessing(configuration).ShouldBeTrue();
+      }
+   }
+
+   public class When_checking_if_a_configuration_must_be_exported_for_further_processing_and_inputs_exist : concern_for_QualificationRunner
+   {
+      [Observation]
+      public void should_be_exported()
+      {
+         var configuration = new QualifcationConfiguration
+         {
+            Inputs = new[] { new Input() }
+         };
+
+         MustBeExportedForFurtherProcessing(configuration).ShouldBeTrue();
+      }
+   }
+
+   public class When_checking_if_a_configuration_must_be_exported_for_further_processing_and_simulation_plots_exist : concern_for_QualificationRunner
+   {
+      [Observation]
+      public void should_be_exported()
+      {
+         var configuration = new QualifcationConfiguration
+         {
+            SimulationPlots = new[] { new SimulationPlot() }
+         };
+
+         MustBeExportedForFurtherProcessing(configuration).ShouldBeTrue();
       }
    }
 

--- a/tests/QualificationRunner.Tests/Services/QualificationRunnerSpecs.cs
+++ b/tests/QualificationRunner.Tests/Services/QualificationRunnerSpecs.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using FakeItEasy;
 using Newtonsoft.Json.Linq;
 using OSPSuite.BDDHelper;
@@ -27,13 +25,6 @@ namespace QualificationRunner.Tests.Services
          sut = new QualificationRunner.Core.Services.QualificationRunner(_jsonSerializer, _logger, _qualificationEngineFactory);
       }
 
-      protected bool MustBeExportedForFurtherProcessing(QualifcationConfiguration configuration)
-      {
-         var method = typeof(QualificationRunner.Core.Services.QualificationRunner)
-            .GetMethod("mustBeExportedForFurtherProcessing", BindingFlags.Instance | BindingFlags.NonPublic);
-
-         return (bool)method.Invoke(sut, new object[] { configuration });
-      }
    }
 
    public class When_running_a_batch_and_the_configuration_file_does_not_exist : concern_for_QualificationRunner
@@ -55,59 +46,6 @@ namespace QualificationRunner.Tests.Services
       {
          The.Action(async () => await sut.RunBatchAsync(_runOptions))
             .ShouldThrowAn<QualificationRunException>();
-      }
-   }
-
-   public class When_checking_if_a_configuration_must_be_exported_for_further_processing_and_no_references_exist : concern_for_QualificationRunner
-   {
-      [Observation]
-      public void should_not_be_exported()
-      {
-         var configuration = new QualifcationConfiguration();
-
-         MustBeExportedForFurtherProcessing(configuration).ShouldBeFalse();
-      }
-   }
-
-   public class When_checking_if_a_configuration_must_be_exported_for_further_processing_and_simulations_exist : concern_for_QualificationRunner
-   {
-      [Observation]
-      public void should_be_exported()
-      {
-         var configuration = new QualifcationConfiguration
-         {
-            Simulations = new[] { "Simulation1" }
-         };
-
-         MustBeExportedForFurtherProcessing(configuration).ShouldBeTrue();
-      }
-   }
-
-   public class When_checking_if_a_configuration_must_be_exported_for_further_processing_and_inputs_exist : concern_for_QualificationRunner
-   {
-      [Observation]
-      public void should_be_exported()
-      {
-         var configuration = new QualifcationConfiguration
-         {
-            Inputs = new[] { new Input() }
-         };
-
-         MustBeExportedForFurtherProcessing(configuration).ShouldBeTrue();
-      }
-   }
-
-   public class When_checking_if_a_configuration_must_be_exported_for_further_processing_and_simulation_plots_exist : concern_for_QualificationRunner
-   {
-      [Observation]
-      public void should_be_exported()
-      {
-         var configuration = new QualifcationConfiguration
-         {
-            SimulationPlots = new[] { new SimulationPlot() }
-         };
-
-         MustBeExportedForFurtherProcessing(configuration).ShouldBeTrue();
       }
    }
 


### PR DESCRIPTION
Fixes #173 Unnecessary starts of PKSim.CLI.exe

As described in the issue, only starting processing of projects, which are directly required for the creation of plots (and or inputs).
Other projects (required for BB/SimParameters-inheritance only) are not processed via **PKSim.CLI**.

(for the inheritance, parent snapshots are loaded anyway in **PKSim.CLI** during processing of the child snapshot - compare e.g.
https://github.com/Open-Systems-Pharmacology/PK-Sim/blob/d3e4114bb8edab3233d6e822c331dd16063becc3/src/PKSim.CLI.Core/Services/QualificationRunner.cs#L281-L314)

The only potential problem with this approach is if someone combines an observed dataset from one project (which is not used for plotting elsewhere) with a simulation from another project in a qualification plan. (https://github.com/Open-Systems-Pharmacology/QualificationRunner/issues/173#issuecomment-4003864544) - but this would be pretty weird and should not be done anyways.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Processing now skips configurations that lack simulations, inputs, or simulation plots, reducing unnecessary task scheduling and improving execution efficiency.

* **Tests**
  * Added comprehensive tests validating the filtering logic across scenarios (no references, simulations present, inputs present, plots present) to ensure correct behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->